### PR TITLE
Spec without inheritance

### DIFF
--- a/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpec.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpec.java
@@ -17,7 +17,7 @@ import java.util.Optional;
  *     The method idiom is copied from: http://jasmine.github.io/2.0/introduction.html.<br>
  * Created by kfgodel on 12/07/14.
  */
-public abstract class  JavaSpec<T extends TestContext> {
+public abstract class JavaSpec<T extends TestContext> implements JavaSpecApi<T> {
 
     private SpecTree specTree;
     private SpecStack stack;
@@ -29,44 +29,27 @@ public abstract class  JavaSpec<T extends TestContext> {
      */
     public abstract void define();
 
-    /**
-     * Code to execute before every it() test. It's scoped to the parent describe() or define(), and executed before every child it() test (direct or nested).<br>
-     * @param aCodeBlock A code to execute before every test
-     */
+    @Override
     public void beforeEach(Runnable aCodeBlock) {
         stack.getCurrentGroup().addBeforeBlock(aCodeBlock);
     }
 
-    /**
-     * Code to execute after every it() test. It's scoped to the parent describe() or define(), and executed after every child it() test (direct or nested).<br>
-     * @param aCodeBlock
-     */
+    @Override
     public void afterEach(Runnable aCodeBlock) {
         stack.getCurrentGroup().addAfterBlock(aCodeBlock);
     }
 
-    /**
-     * Defines the test code to be run as a test.<br> Every parent beforeEach() is executed prior to this test. Every parent afterEach() is executed after.
-     * @param testName The name to identify this test
-     * @param aTestCode The code that defines the test
-     */
+    @Override
     public void it(String testName, Runnable aTestCode){
         addTestDefinition(testName, Optional.of(aTestCode));
     }
 
-    /**
-     * Declares a pending test that will be listed as ignored
-     * @param testName The name to identify this test
-     */
+    @Override
     public void it(String testName){
         addTestDefinition(testName, Optional.empty());
     }
 
-    /**
-     * Declares an ignored test. It will not be run, but listed
-     * @param testName The name to identify this test
-     * @param aTestCode The ignored code of this tests
-     */
+    @Override
     public void xit(String testName, Runnable aTestCode){
         TestSpecDefinition createdTestDefinition = addTestDefinition(testName, Optional.of(aTestCode));
         createdTestDefinition.markAsPending();
@@ -79,20 +62,12 @@ public abstract class  JavaSpec<T extends TestContext> {
     }
 
 
-    /**
-     * Describes a set of test, and allows nesting of scenarios
-     * @param aGroupName The name of the test group
-     * @param aGroupDefinition The code that defines sub-tests, or sub-contexts
-     */
+    @Override
     public void describe(String aGroupName, Runnable aGroupDefinition){
         nestGroupDefinition(aGroupName, aGroupDefinition);
     }
 
-    /**
-     * Declares a disabled suite of tests. Any sub-test or sub-context will be ignored (listed but not run)
-     * @param aGroupName The name identifying the group
-     * @param aGroupDefinition The code that defines sub-tests, or sub-contexts
-     */
+    @Override
     public void xdescribe(String aGroupName, Runnable aGroupDefinition){
         GroupSpecDefinition createdGroup = nestGroupDefinition(aGroupName, aGroupDefinition);
         createdGroup.markAsDisabled();
@@ -120,12 +95,8 @@ public abstract class  JavaSpec<T extends TestContext> {
         this.define();
     }
 
-    /**
-     * Allows access to test context, to define variables or to access them.<br>
-     *  Usually you define variables in suites and access them in tests
-     * @return The current test context
-     */
-    protected T context() {
+    @Override
+    public T context() {
         return typedContext;
     }
 

--- a/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpec.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpec.java
@@ -1,121 +1,72 @@
 package ar.com.dgarcia.javaspec.api;
 
-import ar.com.dgarcia.javaspec.impl.context.typed.TypedContextFactory;
-import ar.com.dgarcia.javaspec.impl.exceptions.SpecException;
-import ar.com.dgarcia.javaspec.impl.model.SpecGroup;
 import ar.com.dgarcia.javaspec.impl.model.SpecTree;
-import ar.com.dgarcia.javaspec.impl.model.impl.GroupSpecDefinition;
-import ar.com.dgarcia.javaspec.impl.model.impl.SpecTreeDefinition;
-import ar.com.dgarcia.javaspec.impl.model.impl.TestSpecDefinition;
-import ar.com.dgarcia.javaspec.impl.parser.SpecStack;
-
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.Optional;
+import ar.com.dgarcia.javaspec.impl.parser.SpecInterpreter;
 
 /**
  * This class is the extension point to add testing expressiveness with Java Specs.<br>
- *     The method idiom is copied from: http://jasmine.github.io/2.0/introduction.html.<br>
+ * The method idiom is copied from: http://jasmine.github.io/2.0/introduction.html.<br>
  * Created by kfgodel on 12/07/14.
  */
 public abstract class JavaSpec<T extends TestContext> implements JavaSpecApi<T> {
 
-    private SpecStack stack;
-    private Variable<TestContext> sharedContext;
-    private T typedContext;
+  private SpecInterpreter<T> interpreter;
 
-    /**
-     * Starting method to define the specs.<br>
-     *     This method must be extended by subclasses and define any spec as calls to describe() and it()
-     */
-    public abstract void define();
+  /**
+   * Starting method to define the specs.<br>
+   * This method must be extended by subclasses and define any spec as calls to describe() and it()
+   */
+  public abstract void define();
 
-    @Override
-    public void beforeEach(Runnable aCodeBlock) {
-        stack.getCurrentGroup().addBeforeBlock(aCodeBlock);
-    }
+  /**
+   * Creates a spec definition tree with the specification defined by the user in the subclass
+   */
+  public SpecTree defineTree() {
+    // Needs to be instance variable to be accesed in the define method
+    this.interpreter = SpecInterpreter.create(this.getClass());
 
-    @Override
-    public void afterEach(Runnable aCodeBlock) {
-        stack.getCurrentGroup().addAfterBlock(aCodeBlock);
-    }
+    this.define();
 
-    @Override
-    public void it(String testName, Runnable aTestCode){
-        addTestDefinition(testName, Optional.of(aTestCode));
-    }
+    return interpreter.getSpecTree();
+  }
 
-    @Override
-    public void it(String testName){
-        addTestDefinition(testName, Optional.empty());
-    }
+  @Override
+  public T context() {
+    return interpreter.context();
+  }
 
-    @Override
-    public void xit(String testName, Runnable aTestCode){
-        TestSpecDefinition createdTestDefinition = addTestDefinition(testName, Optional.of(aTestCode));
-        createdTestDefinition.markAsPending();
-    }
+  @Override
+  public void beforeEach(Runnable aCodeBlock) {
+    interpreter.beforeEach(aCodeBlock);
+  }
 
-    private TestSpecDefinition addTestDefinition(String testName, Optional<Runnable> testBody) {
-        TestSpecDefinition createdSpec = TestSpecDefinition.create(testName, testBody, sharedContext);
-        stack.getCurrentGroup().addSubElement(createdSpec);
-        return createdSpec;
-    }
+  @Override
+  public void afterEach(Runnable aCodeBlock) {
+    interpreter.afterEach(aCodeBlock);
+  }
 
+  @Override
+  public void it(String testName, Runnable aTestCode) {
+    interpreter.it(testName, aTestCode);
+  }
 
-    @Override
-    public void describe(String aGroupName, Runnable aGroupDefinition){
-        nestGroupDefinition(aGroupName, aGroupDefinition);
-    }
+  @Override
+  public void it(String testName) {
+    interpreter.it(testName);
+  }
 
-    @Override
-    public void xdescribe(String aGroupName, Runnable aGroupDefinition){
-        GroupSpecDefinition createdGroup = nestGroupDefinition(aGroupName, aGroupDefinition);
-        createdGroup.markAsDisabled();
-    }
+  @Override
+  public void xit(String testName, Runnable aTestCode) {
+    interpreter.xit(testName, aTestCode);
+  }
 
-    private GroupSpecDefinition nestGroupDefinition(String aGroupName, Runnable definitionBlock) {
-        GroupSpecDefinition createdGroup = GroupSpecDefinition.create(aGroupName);
-        stack.runNesting(createdGroup, definitionBlock::run);
-        return createdGroup;
-    }
+  @Override
+  public void describe(String aGroupName, Runnable aGroupDefinition) {
+    interpreter.describe(aGroupName, aGroupDefinition);
+  }
 
-
-    /**
-     * Creates a spec definition tree with the specification defined by the user in the subclass
-     */
-    public SpecTree defineTree() {
-        SpecTree specTree = SpecTreeDefinition.create(this.getClass());
-
-        this.sharedContext = Variable.create();
-        SpecGroup rootGroup = specTree.getRootGroup();
-        this.stack = SpecStack.create(rootGroup, sharedContext);
-
-        Class<T> expectedContextType = this.getContextTypeFromSubclassDeclaration();
-        this.typedContext = TypedContextFactory.createInstanceOf(expectedContextType, sharedContext);
-
-        this.define();
-        return specTree;
-    }
-
-    @Override
-    public T context() {
-        return typedContext;
-    }
-
-    public Class<T> getContextTypeFromSubclassDeclaration() {
-        Class<? extends JavaSpec> subClass = getClass();
-        if(!(subClass.getSuperclass().equals(JavaSpec.class))){
-            throw new SpecException("A java spec class["+ subClass+ "] must inherit directly from " +JavaSpec.class);
-        }
-        Type generifiedJavaSpec = subClass.getGenericSuperclass();
-        if(!(generifiedJavaSpec instanceof ParameterizedType)){
-            throw new SpecException("JavaSpec superclass must be generified with a type of TestContext. For example JavaSpec<TestContext>");
-        }
-        Type contextType = ((ParameterizedType) generifiedJavaSpec).getActualTypeArguments()[0];
-        if(!(contextType instanceof Class)){
-            throw new SpecException("JavaSpec parameter is not a class?");
-        }
-        return (Class<T>) contextType;
-    }
+  @Override
+  public void xdescribe(String aGroupName, Runnable aGroupDefinition) {
+    interpreter.xdescribe(aGroupName, aGroupDefinition);
+  }
 }

--- a/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpec.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpec.java
@@ -1,7 +1,5 @@
 package ar.com.dgarcia.javaspec.api;
 
-import ar.com.dgarcia.javaspec.impl.model.SpecTree;
-import ar.com.dgarcia.javaspec.impl.parser.DefinitionInterpreter;
 import ar.com.dgarcia.javaspec.impl.parser.ExecutionInterpreter;
 
 /**
@@ -9,7 +7,7 @@ import ar.com.dgarcia.javaspec.impl.parser.ExecutionInterpreter;
  * The method idiom is copied from: http://jasmine.github.io/2.0/introduction.html.<br>
  * Created by kfgodel on 12/07/14.
  */
-public abstract class JavaSpec<T extends TestContext> implements JavaSpecApi<T> {
+public abstract class JavaSpec<T extends TestContext> implements JavaSpecApi<T>, JavaSpecTestable<T> {
 
   private JavaSpecApi<T> currentInterpreter;
 
@@ -19,19 +17,13 @@ public abstract class JavaSpec<T extends TestContext> implements JavaSpecApi<T> 
    */
   public abstract void define();
 
-  /**
-   * Creates a spec definition tree with the specification defined by the user in the subclass
-   */
-  public SpecTree defineTree() {
-    DefinitionInterpreter<T> definitionInterpreter = DefinitionInterpreter.create(this.getClass());
-
+  @Override
+  public void defineSpecs(JavaSpecApi<T> spec) {
     // Needs to be instance variable to be accesed in the define method
-    this.currentInterpreter = definitionInterpreter;
+    this.currentInterpreter = spec;
     this.define();
     // We lock every method call after definition, to prevent inadverted user errors
-    this.currentInterpreter = ExecutionInterpreter.create(definitionInterpreter);
-
-    return definitionInterpreter.getSpecTree();
+    this.currentInterpreter = ExecutionInterpreter.create(spec);
   }
 
   @Override

--- a/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpecApi.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpecApi.java
@@ -1,0 +1,61 @@
+package ar.com.dgarcia.javaspec.api;
+
+/**
+ * This type represents the available api for tests written with Java-Spec
+ * Created by tenpines on 31/12/15.
+ */
+public interface JavaSpecApi<T extends TestContext> {
+
+  /**
+   * Code to execute before every it() test. It's scoped to the parent describe() or define(), and executed before every child it() test (direct or nested).<br>
+   * @param aCodeBlock A code to execute before every test
+   */
+  void beforeEach(Runnable aCodeBlock);
+
+  /**
+   * Code to execute after every it() test. It's scoped to the parent describe() or define(), and executed after every child it() test (direct or nested).<br>
+   * @param aCodeBlock
+   */
+  void afterEach(Runnable aCodeBlock);
+
+  /**
+   * Defines the test code to be run as a test.<br> Every parent beforeEach() is executed prior to this test. Every parent afterEach() is executed after.
+   * @param testName The name to identify this test
+   * @param aTestCode The code that defines the test
+   */
+  void it(String testName, Runnable aTestCode);
+
+  /**
+   * Declares a pending test that will be listed as ignored
+   * @param testName The name to identify this test
+   */
+  void it(String testName);
+
+  /**
+   * Declares an ignored test. It will not be run, but listed
+   * @param testName The name to identify this test
+   * @param aTestCode The ignored code of this tests
+   */
+  void xit(String testName, Runnable aTestCode);
+
+  /**
+   * Describes a set of test, and allows nesting of scenarios
+   * @param aGroupName The name of the test group
+   * @param aGroupDefinition The code that defines sub-tests, or sub-contexts
+   */
+  void describe(String aGroupName, Runnable aGroupDefinition);
+
+  /**
+   * Declares a disabled suite of tests. Any sub-test or sub-context will be ignored (listed but not run)
+   * @param aGroupName The name identifying the group
+   * @param aGroupDefinition The code that defines sub-tests, or sub-contexts
+   */
+  void xdescribe(String aGroupName, Runnable aGroupDefinition);
+
+  /**
+   * Allows access to test context, to define variables or to access them.<br>
+   *  Usually you define variables in suites and access them in tests
+   * @return The current test context
+   */
+  T context();
+}

--- a/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpecApi.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpecApi.java
@@ -1,7 +1,8 @@
 package ar.com.dgarcia.javaspec.api;
 
 /**
- * This type represents the available api for tests written with Java-Spec
+ * This type represents the public available api for tests written using Java-Spec.<br>
+ *   The methods defined here are to be used by users of JavaSpec
  * Created by tenpines on 31/12/15.
  */
 public interface JavaSpecApi<T extends TestContext> {

--- a/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpecRunner.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpecRunner.java
@@ -1,17 +1,16 @@
 package ar.com.dgarcia.javaspec.api;
 
-import java.util.List;
-
+import ar.com.dgarcia.javaspec.impl.junit.JunitTestCode;
+import ar.com.dgarcia.javaspec.impl.junit.JunitTestTreeAdapter;
+import ar.com.dgarcia.javaspec.impl.model.SpecTree;
+import ar.com.dgarcia.javaspec.impl.parser.SpecParser;
 import org.junit.runner.Description;
 import org.junit.runner.Runner;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.RunnerBuilder;
 
-import ar.com.dgarcia.javaspec.impl.junit.JunitTestCode;
-import ar.com.dgarcia.javaspec.impl.junit.JunitTestTreeAdapter;
-import ar.com.dgarcia.javaspec.impl.model.SpecTree;
-import ar.com.dgarcia.javaspec.impl.parser.SpecParser;
+import java.util.List;
 
 /**
  * This type implements the Java Spec runner needed to extend Junit running mechanism
@@ -34,18 +33,18 @@ public class JavaSpecRunner extends Runner {
             throw new InitializationError("Your class["+klass+"] must extend " + JavaSpec.class + " to be run with " +  JavaSpecRunner.class.getSimpleName());
         }
         this.clase = (Class<? extends JavaSpec>) klass;
-        createJunitTestTreeFromSpecClass();
+        junitAdapter = createJunitTestTreeFromSpecClass();
     }
 
     /**
      * Creates the test tree to be used to describe and execute the tests in junit
      */
-    private void createJunitTestTreeFromSpecClass() throws InitializationError {
+    private JunitTestTreeAdapter createJunitTestTreeFromSpecClass() throws InitializationError {
         SpecTree specTree = SpecParser.create().parse(clase);
         if(specTree.hasNoTests()){
             throw new InitializationError("The spec class["+clase.getSimpleName()+"] has no tests. You must at least use one it() or one xit() inside your definition method");
         }
-        junitAdapter = JunitTestTreeAdapter.create(specTree, clase);
+        return JunitTestTreeAdapter.create(specTree, clase);
     }
 
 

--- a/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpecRunner.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpecRunner.java
@@ -44,7 +44,7 @@ public class JavaSpecRunner extends Runner {
         if(specTree.hasNoTests()){
             throw new InitializationError("The spec class["+clase.getSimpleName()+"] has no tests. You must at least use one it() or one xit() inside your definition method");
         }
-        return JunitTestTreeAdapter.create(specTree, clase);
+        return JunitTestTreeAdapter.create(specTree);
     }
 
 

--- a/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpecRunner.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpecRunner.java
@@ -18,7 +18,6 @@ import java.util.List;
  */
 public class JavaSpecRunner extends Runner {
 
-    private Class<? extends JavaSpec> clase;
     private JunitTestTreeAdapter junitAdapter;
 
     /**
@@ -29,22 +28,17 @@ public class JavaSpecRunner extends Runner {
      */
     @SuppressWarnings("unchecked")
 	public JavaSpecRunner(Class<?> klass, RunnerBuilder builder) throws InitializationError {
-        if(!JavaSpec.class.isAssignableFrom(klass)){
-            throw new InitializationError("Your class["+klass+"] must extend " + JavaSpec.class + " to be run with " +  JavaSpecRunner.class.getSimpleName());
+        SpecParser specParser = SpecParser.create();
+        SpecTree specTree = null;
+        try {
+            specTree = specParser.parse(klass);
+        } catch (IllegalArgumentException e) {
+            throw new InitializationError(e);
         }
-        this.clase = (Class<? extends JavaSpec>) klass;
-        junitAdapter = createJunitTestTreeFromSpecClass();
-    }
-
-    /**
-     * Creates the test tree to be used to describe and execute the tests in junit
-     */
-    private JunitTestTreeAdapter createJunitTestTreeFromSpecClass() throws InitializationError {
-        SpecTree specTree = SpecParser.create().parse(clase);
         if(specTree.hasNoTests()){
-            throw new InitializationError("The spec class["+clase.getSimpleName()+"] has no tests. You must at least use one it() or one xit() inside your definition method");
+            throw new InitializationError("The spec class["+ ((Class<? extends JavaSpec>) klass).getSimpleName()+"] has no tests. You must at least use one it() or one xit() inside your definition method");
         }
-        return JunitTestTreeAdapter.create(specTree);
+        junitAdapter = JunitTestTreeAdapter.create(specTree);
     }
 
 

--- a/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpecTestable.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpecTestable.java
@@ -1,0 +1,15 @@
+package ar.com.dgarcia.javaspec.api;
+
+/**
+ * This type is implemented by classes that define test without requiring inheritance
+ * Created by tenpines on 02/01/16.
+ */
+public interface JavaSpecTestable<T extends TestContext> {
+
+  /**
+   * Implemented by subtypes to define the specs that should be run as this test instance
+   * @param spec The spec api to define the specs
+   */
+  void defineSpecs(JavaSpecApi<T> spec);
+
+}

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/context/MappedContext.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/context/MappedContext.java
@@ -104,10 +104,15 @@ public class MappedContext implements TestContextDefinition{
         return getVariableValues().containsKey(variableName);
     }
 
-    public static MappedContext create() {
+    public static MappedContext createWithParent(TestContextDefinition parentDefinition) {
         MappedContext context = new MappedContext();
-        context.parentDefinition = NullContextDefinition.create();
+        context.parentDefinition = parentDefinition;
         return context;
+    }
+
+
+    public static MappedContext create() {
+        return createWithParent(NullContextDefinition.create());
     }
 
     @Override

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/junit/JunitIgnoredTestCode.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/junit/JunitIgnoredTestCode.java
@@ -1,0 +1,33 @@
+package ar.com.dgarcia.javaspec.impl.junit;
+
+import org.junit.internal.runners.model.EachTestNotifier;
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunNotifier;
+
+/**
+ * This type represents a test code to be ignored by Junit
+ * Created by kfgodel on 13/07/14.
+ */
+public class JunitIgnoredTestCode implements JunitTestCode {
+
+    private Description testDescription;
+
+    /**
+     * Executes this test code, notifying the given notifier for state changes
+     * @param notifier The notifier for this test
+     */
+    public void executeNotifying(RunNotifier notifier) {
+        EachTestNotifier testNotifier = new EachTestNotifier(notifier, testDescription);
+        testNotifier.fireTestIgnored();
+    }
+
+    public static JunitIgnoredTestCode create(Description testDescription) {
+        JunitIgnoredTestCode junitTestCode = new JunitIgnoredTestCode();
+        junitTestCode.testDescription = testDescription;
+        return junitTestCode;
+    }
+
+    public Description getTestDescription() {
+        return testDescription;
+    }
+}

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/junit/JunitRunnableTestCode.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/junit/JunitRunnableTestCode.java
@@ -1,0 +1,45 @@
+package ar.com.dgarcia.javaspec.impl.junit;
+
+import org.junit.internal.AssumptionViolatedException;
+import org.junit.internal.runners.model.EachTestNotifier;
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunNotifier;
+
+/**
+ * This type represents a test code to be tested with Junit
+ * Created by kfgodel on 13/07/14.
+ */
+public class JunitRunnableTestCode implements JunitTestCode {
+
+    private Runnable testCode;
+    private Description testDescription;
+
+    /**
+     * Executes this test code, notifying the given notifier for state changes
+     * @param notifier The notifier for this test
+     */
+    public void executeNotifying(RunNotifier notifier) {
+        EachTestNotifier testNotifier = new EachTestNotifier(notifier, testDescription);
+        testNotifier.fireTestStarted();
+        try {
+            testCode.run();
+        } catch (AssumptionViolatedException e) {
+            testNotifier.addFailedAssumption(e);
+        } catch (Throwable e) {
+            testNotifier.addFailure(e);
+        } finally {
+            testNotifier.fireTestFinished();
+        }
+    }
+
+    public static JunitRunnableTestCode create(Runnable testCode, Description testDescription) {
+        JunitRunnableTestCode junitRunnableTestCode = new JunitRunnableTestCode();
+        junitRunnableTestCode.testCode = testCode;
+        junitRunnableTestCode.testDescription = testDescription;
+        return junitRunnableTestCode;
+    }
+
+    public Description getTestDescription() {
+        return testDescription;
+    }
+}

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/junit/JunitTestCode.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/junit/JunitTestCode.java
@@ -1,55 +1,22 @@
 package ar.com.dgarcia.javaspec.impl.junit;
 
-import org.junit.internal.AssumptionViolatedException;
-import org.junit.internal.runners.model.EachTestNotifier;
 import org.junit.runner.Description;
 import org.junit.runner.notification.RunNotifier;
 
 /**
- * This type represents a test code to be tested with Junit
- * Created by kfgodel on 13/07/14.
+ * This type represents a junit adapted test according to a spec definition.
+ * Created by tenpines on 31/12/15.
  */
-public class JunitTestCode {
+public interface JunitTestCode {
 
-    private Runnable testCode;
-    private Description testDescription;
-    private boolean mustIgnore;
+  /**
+   * Executes this test code, notifying the given notifier for state changes
+   * @param notifier The notifier for this test
+   */
+  void executeNotifying(RunNotifier notifier);
 
-    /**
-     * Executes this test code, notifying the given notifier for state changes
-     * @param notifier The notifier for this test
-     */
-    public void executeNotifying(RunNotifier notifier) {
-        EachTestNotifier testNotifier = new EachTestNotifier(notifier, testDescription);
-        if (mustIgnore) {
-            testNotifier.fireTestIgnored();
-            return;
-        }
-        testNotifier.fireTestStarted();
-        try {
-            testCode.run();
-        } catch (AssumptionViolatedException e) {
-            testNotifier.addFailedAssumption(e);
-        } catch (Throwable e) {
-            testNotifier.addFailure(e);
-        } finally {
-            testNotifier.fireTestFinished();
-        }
-    }
-
-    public static JunitTestCode create(Runnable testCode, Description testDescription) {
-        JunitTestCode junitTestCode = new JunitTestCode();
-        junitTestCode.testCode = testCode;
-        junitTestCode.testDescription = testDescription;
-        junitTestCode.mustIgnore = false;
-        return junitTestCode;
-    }
-
-    public void ignoreTest(){
-        this.mustIgnore = true;
-    }
-
-    public Description getTestDescription() {
-        return testDescription;
-    }
+  /**
+   * @return Describes this test for junit
+   */
+  Description getTestDescription();
 }

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/junit/JunitTestTreeAdapter.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/junit/JunitTestTreeAdapter.java
@@ -9,6 +9,7 @@ import org.junit.runner.Description;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * This type adapts the SpecTree to a Junit test tree by giving it a description and surrounding each test spec in a JunitTestCode
@@ -61,11 +62,11 @@ public class JunitTestTreeAdapter {
     }
 
     private JunitTestCode adaptToJunitTest(SpecTest specTest, Description elementDescription) {
-        Runnable specTestCode = specTest.getSpecExecutionCode();
-        JunitTestCode junitTest = JunitTestCode.create(specTestCode, elementDescription);
-        if(specTest.isMarkedAsPending()){
-            junitTest.ignoreTest();
-        }
+        Optional<Runnable> fullTestCode = specTest.getFullExecutionCode();
+        // Convert the spec code to a junit equivalent, taking into account if it's marked as ignored
+        JunitTestCode junitTest = fullTestCode
+          .map((runnable)-> (JunitTestCode) JunitRunnableTestCode.create(runnable, elementDescription))
+          .orElse(JunitIgnoredTestCode.create(elementDescription));
         return junitTest;
     }
 

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/junit/JunitTestTreeAdapter.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/junit/JunitTestTreeAdapter.java
@@ -1,6 +1,5 @@
 package ar.com.dgarcia.javaspec.impl.junit;
 
-import ar.com.dgarcia.javaspec.api.JavaSpec;
 import ar.com.dgarcia.javaspec.impl.model.SpecElement;
 import ar.com.dgarcia.javaspec.impl.model.SpecGroup;
 import ar.com.dgarcia.javaspec.impl.model.SpecTest;
@@ -22,59 +21,60 @@ public class JunitTestTreeAdapter {
     private SpecTree specTree;
     private JunitTestTree junitTree;
 
-    public static JunitTestTreeAdapter create(SpecTree specTree, Class<? extends JavaSpec> clase) {
+    public static JunitTestTreeAdapter create(SpecTree specTree) {
         JunitTestTreeAdapter adapter = new JunitTestTreeAdapter();
         adapter.specTree = specTree;
-        adapter.adaptToJunit(clase);
+        adapter.adaptToJunit();
         return adapter;
     }
 
     /**
      * Creates a junit test tree with the spec tree
-     * @param clase
      */
-    private void adaptToJunit(Class<? extends JavaSpec> clase) {
-    	Description rootDescription = Description.createSuiteDescription(clase);
+    private void adaptToJunit() {
+        Description rootDescription = Description.createSuiteDescription(specTree.getDefiningClass());
         junitTree = JunitTestTree.create(rootDescription);
+
         SpecGroup rootGroup = specTree.getRootGroup();
-        recursiveAdaptToJunit(rootGroup, rootDescription);
+        adaptGroupToJunit(rootGroup, rootDescription);
     }
 
-    private void recursiveAdaptToJunit(SpecGroup currentGroup, Description currentDescription) {
+    private void adaptGroupToJunit(SpecGroup currentGroup, Description currentDescription) {
         List<SpecElement> specElements = currentGroup.getSpecElements();
         for (SpecElement specElement : specElements) {
-
-            String specName = specElement.getName();
-            String specId = specName + String.valueOf(specElement.hashCode());
-            Description elementDescription = Description.createSuiteDescription(specName, specId, NO_ANNOTATIONS);
-            currentDescription.addChild(elementDescription);
-
-            if(specElement instanceof SpecTest){
-                JunitTestCode junitTest = adaptToJunitTest((SpecTest) specElement, elementDescription);
-                this.junitTree.addTest(junitTest);
-            }
-
-            if(specElement instanceof SpecGroup){
-                SpecGroup specGroup = (SpecGroup) specElement;
-                recursiveAdaptToJunit(specGroup, elementDescription);
-            }
+            adaptElementToJunit(currentDescription, specElement);
         }
     }
 
-    private JunitTestCode adaptToJunitTest(SpecTest specTest, Description elementDescription) {
-        Optional<Runnable> fullTestCode = specTest.getFullExecutionCode();
-        // Convert the spec code to a junit equivalent, taking into account if it's marked as ignored
-        JunitTestCode junitTest = fullTestCode
-          .map((runnable)-> (JunitTestCode) JunitRunnableTestCode.create(runnable, elementDescription))
-          .orElse(JunitIgnoredTestCode.create(elementDescription));
-        return junitTest;
+    private void adaptElementToJunit(Description parentDescription, SpecElement specElement) {
+      Description elementDescription = createElementDescription(specElement);
+      parentDescription.addChild(elementDescription);
+
+      if (specElement instanceof SpecTest) {
+        adaptTestToJunit((SpecTest) specElement, elementDescription);
+      }
+
+      if (specElement instanceof SpecGroup) {
+        adaptGroupToJunit((SpecGroup) specElement, elementDescription);
+      }
     }
+
+  private Description createElementDescription(SpecElement specElement) {
+    String specName = specElement.getName();
+    String specId = specName + String.valueOf(specElement.hashCode());
+    return Description.createSuiteDescription(specName, specId, NO_ANNOTATIONS);
+  }
+
+  private void adaptTestToJunit(SpecTest specTest, Description elementDescription) {
+    Optional<Runnable> fullTestCode = specTest.getFullExecutionCode();
+    // Convert the spec code to a junit equivalent, taking into account if it's marked as ignored
+    JunitTestCode junitTest = fullTestCode
+      .map((runnable) -> (JunitTestCode) JunitRunnableTestCode.create(runnable, elementDescription))
+      .orElse(JunitIgnoredTestCode.create(elementDescription));
+    this.junitTree.addTest(junitTest);
+  }
 
     public JunitTestTree getJunitTree() {
         return junitTree;
-    }
-
-    public SpecTree getSpecTree() {
-        return specTree;
     }
 }

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/model/SpecGroup.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/model/SpecGroup.java
@@ -1,8 +1,5 @@
 package ar.com.dgarcia.javaspec.impl.model;
 
-import ar.com.dgarcia.javaspec.impl.model.impl.GroupSpecDefinition;
-import ar.com.dgarcia.javaspec.impl.model.impl.TestSpecDefinition;
-
 import java.util.List;
 
 /**
@@ -45,17 +42,11 @@ public interface SpecGroup extends SpecElement {
      */
     void markAsDisabled();
 
-    /**
-     * Adds a new group definition to this group.<br>
-     * @param addedGroup The group to add as child of this
-     */
-    void addSubGroup(GroupSpecDefinition addedGroup);
-
-    /**
-     * Adds a new test spec to this group
-     * @param addedSpec The test to add as child of this group
-     */
-    void addTest(TestSpecDefinition addedSpec);
+  /**
+   * Adds a new element to this subgroup as a sub element (group or test)
+   * @param subElement The test or group to add
+   */
+  void addSubElement(SpecElement subElement);
 
     /**
      * Adds a before block to this group definition. Every test on this group, and every subgroup will execute it

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/model/SpecTest.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/model/SpecTest.java
@@ -1,6 +1,8 @@
 package ar.com.dgarcia.javaspec.impl.model;
 
 
+import java.util.Optional;
+
 /**
  * This type represents a single test to be run in a spec
  * Created by kfgodel on 12/07/14.
@@ -20,11 +22,11 @@ public interface SpecTest extends SpecElement {
 
 
     /**
-     * Returns the code that defines this test execution.<br>
-     *     Code may be null if this is a pending test
+     * Returns the code that is particular to this test as defined by the user.<br>
+     *     Code may be not be available if this is a pending test
      * @return The code to run for this test
      */
-    Runnable getTestCode();
+    Optional<Runnable> getTestBodyCode();
 
     /**
      * Marks this test spec as pending.<br>
@@ -33,8 +35,9 @@ public interface SpecTest extends SpecElement {
     void markAsPending();
 
     /**
-     * Returns a code block to be run as the spec. It will execute before and after code blocks as well as test code.
+     * Returns a code block to be run as the full spec. Including before and after code blocks as well as test code,
+     * as a single runnable unit.
      * @return The code to execute as a complete spec test
      */
-    Runnable getSpecExecutionCode();
+    Optional<Runnable> getFullExecutionCode();
 }

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/model/SpecTree.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/model/SpecTree.java
@@ -1,8 +1,5 @@
 package ar.com.dgarcia.javaspec.impl.model;
 
-import ar.com.dgarcia.javaspec.api.TestContext;
-import ar.com.dgarcia.javaspec.api.Variable;
-
 /**
  * This type represents the specification of tests defined in one subclass of JavaSpec
  * Created by kfgodel on 12/07/14.
@@ -20,9 +17,9 @@ public interface SpecTree {
      */
     SpecGroup getRootGroup();
 
-    /**
-     * Variable shared between tests to replace context instance on test execution
-     * @return The variable used to define active context in each test
-     */
-    Variable<TestContext> getSharedContext();
+  /**
+   * The class in which this tree is defined
+   */
+  Class<?> getDefiningClass();
+
 }

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/model/impl/GroupSpecDefinition.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/model/impl/GroupSpecDefinition.java
@@ -53,13 +53,11 @@ public class GroupSpecDefinition extends SpecElementSupport implements SpecGroup
     }
 
     @Override
-    public void addSubGroup(GroupSpecDefinition addedGroup) {
-        this.addContainedElement(addedGroup);
-    }
-
-    @Override
-    public void addTest(TestSpecDefinition addedSpec) {
-        this.addContainedElement(addedSpec);
+    public void addSubElement(SpecElement subElement) {
+        if(!SpecElementSupport.class.isInstance(subElement)){
+            throw new UnsupportedOperationException("This class doesn't support elements that are not instances of " + SpecElementSupport.class);
+        }
+        this.addContainedElement((SpecElementSupport) subElement);
     }
 
     @Override

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/model/impl/NullContainerGroup.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/model/impl/NullContainerGroup.java
@@ -58,13 +58,8 @@ public class NullContainerGroup implements SpecGroup {
     }
 
     @Override
-    public void addSubGroup(GroupSpecDefinition addedGroup) {
-        throw new UnsupportedOperationException("Null container cannot have subgroup");
-    }
-
-    @Override
-    public void addTest(TestSpecDefinition addedSpec) {
-        throw new UnsupportedOperationException("Null container cannot have test");
+    public void addSubElement(SpecElement subElement) {
+        throw new UnsupportedOperationException("Null container cannot have sub elements");
     }
 
     @Override

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/model/impl/SpecExecutionBlock.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/model/impl/SpecExecutionBlock.java
@@ -30,8 +30,7 @@ public class SpecExecutionBlock implements Runnable {
      * @param codeToRun Code to run in own context
      */
     private void runWithOwnSubContext(Runnable codeToRun) {
-        MappedContext testRunContext = MappedContext.create();
-        testRunContext.setParentDefinition(parentContext);
+        MappedContext testRunContext = MappedContext.createWithParent(parentContext);
 
         TestContext previousContext = sharedContext.get();
         sharedContext.set(testRunContext);

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/model/impl/SpecExecutionBlock.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/model/impl/SpecExecutionBlock.java
@@ -17,12 +17,12 @@ public class SpecExecutionBlock implements Runnable {
     private Variable<TestContext> sharedContext;
     private TestContextDefinition parentContext;
     private List<Runnable> beforeBlocks;
-    private Runnable testCode;
+    private Runnable testBlock;
     private List<Runnable> afterBlocks;
 
     @Override
     public void run() {
-        runWithOwnSubContext(() -> executeTestCode());
+        runWithOwnSubContext(this::executeTestCode);
     }
 
     /**
@@ -46,15 +46,15 @@ public class SpecExecutionBlock implements Runnable {
         for (Runnable beforeBlock : beforeBlocks) {
             beforeBlock.run();
         }
-        testCode.run();
+        testBlock.run();
         for (Runnable afterBlock : afterBlocks) {
             afterBlock.run();
         }
     }
 
-    public static SpecExecutionBlock create(List<Runnable> befores, Runnable testCode, List<Runnable> afters, TestContextDefinition parentContext, Variable<TestContext> sharedContext) {
+    public static SpecExecutionBlock create(List<Runnable> befores, Runnable testBlock, List<Runnable> afters, TestContextDefinition parentContext, Variable<TestContext> sharedContext) {
         SpecExecutionBlock executionBlock = new SpecExecutionBlock();
-        executionBlock.testCode = testCode;
+        executionBlock.testBlock = testBlock;
         executionBlock.afterBlocks = afters;
         executionBlock.beforeBlocks = befores;
         executionBlock.sharedContext = sharedContext;

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/model/impl/SpecTreeDefinition.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/model/impl/SpecTreeDefinition.java
@@ -1,7 +1,5 @@
 package ar.com.dgarcia.javaspec.impl.model.impl;
 
-import ar.com.dgarcia.javaspec.api.TestContext;
-import ar.com.dgarcia.javaspec.api.Variable;
 import ar.com.dgarcia.javaspec.impl.model.SpecGroup;
 import ar.com.dgarcia.javaspec.impl.model.SpecTree;
 
@@ -12,7 +10,12 @@ import ar.com.dgarcia.javaspec.impl.model.SpecTree;
 public class SpecTreeDefinition implements SpecTree {
 
     private SpecGroup rootGroup;
-    private Variable<TestContext> sharedContext;
+
+    public Class<?> getDefiningClass() {
+        return definingClass;
+    }
+
+    private Class<?> definingClass;
 
     @Override
     public boolean hasNoTests() {
@@ -24,14 +27,12 @@ public class SpecTreeDefinition implements SpecTree {
         return rootGroup;
     }
 
-    public static SpecTreeDefinition create() {
+    public static SpecTreeDefinition create(Class<?> definingClass) {
         SpecTreeDefinition tree = new SpecTreeDefinition();
-        tree.rootGroup = GroupSpecDefinition.create("anonymous root");
-        tree.sharedContext = Variable.create();
+        tree.definingClass = definingClass;
+        String rootGroupName = definingClass.getSimpleName() + " root";
+        tree.rootGroup = GroupSpecDefinition.create(rootGroupName);
         return tree;
     }
 
-    public Variable<TestContext> getSharedContext() {
-        return sharedContext;
-    }
 }

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/parser/DefinitionInterpreter.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/parser/DefinitionInterpreter.java
@@ -22,7 +22,7 @@ import java.util.Optional;
  *
  * Created by tenpines on 31/12/15.
  */
-public class SpecInterpreter<T extends TestContext> implements JavaSpecApi<T> {
+public class DefinitionInterpreter<T extends TestContext> implements JavaSpecApi<T> {
 
   private SpecTreeDefinition specTree;
   private Variable<TestContext> sharedContext;
@@ -30,8 +30,8 @@ public class SpecInterpreter<T extends TestContext> implements JavaSpecApi<T> {
   private T typedContext;
   private Class<?> specClass;
 
-  public static<T extends TestContext> SpecInterpreter<T> create(Class<?> specClass){
-    SpecInterpreter<T> interpreter = new SpecInterpreter<>();
+  public static<T extends TestContext> DefinitionInterpreter<T> create(Class<?> specClass){
+    DefinitionInterpreter<T> interpreter = new DefinitionInterpreter<>();
     interpreter.specClass = specClass;
     interpreter.initialize();
     return interpreter;

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/parser/ExecutionInterpreter.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/parser/ExecutionInterpreter.java
@@ -11,7 +11,7 @@ import ar.com.dgarcia.javaspec.impl.exceptions.SpecException;
  * Created by tenpines on 31/12/15.
  */
 public class ExecutionInterpreter<T extends TestContext> implements JavaSpecApi<T> {
-  private DefinitionInterpreter<T> definitionInterpreter;
+  private JavaSpecApi<T> definitionInterpreter;
 
   @Override
   public void beforeEach(Runnable aCodeBlock) {
@@ -53,7 +53,7 @@ public class ExecutionInterpreter<T extends TestContext> implements JavaSpecApi<
     return definitionInterpreter.context();
   }
 
-  public static<T extends TestContext> ExecutionInterpreter<T> create(DefinitionInterpreter<T> definitionInterpreter){
+  public static<T extends TestContext> ExecutionInterpreter<T> create(JavaSpecApi<T> definitionInterpreter){
     ExecutionInterpreter<T> executionInterpreter = new ExecutionInterpreter<>();
     executionInterpreter.definitionInterpreter = definitionInterpreter;
     return executionInterpreter;

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/parser/ExecutionInterpreter.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/parser/ExecutionInterpreter.java
@@ -1,0 +1,61 @@
+package ar.com.dgarcia.javaspec.impl.parser;
+
+import ar.com.dgarcia.javaspec.api.JavaSpecApi;
+import ar.com.dgarcia.javaspec.api.TestContext;
+import ar.com.dgarcia.javaspec.impl.exceptions.SpecException;
+
+/**
+ * This type represents the interpreter that rejects user actions trying to define spec after
+ * the tree has been already parsed.
+ *
+ * Created by tenpines on 31/12/15.
+ */
+public class ExecutionInterpreter<T extends TestContext> implements JavaSpecApi<T> {
+  private DefinitionInterpreter<T> definitionInterpreter;
+
+  @Override
+  public void beforeEach(Runnable aCodeBlock) {
+    throw new SpecException("Cannot call beforeEach during the execution of a test");
+  }
+
+  @Override
+  public void afterEach(Runnable aCodeBlock) {
+    throw new SpecException("Cannot call afterEach during the execution of a test");
+  }
+
+  @Override
+  public void it(String testName, Runnable aTestCode) {
+    throw new SpecException("Cannot call it(\""+testName+"\") during the execution of a test");
+  }
+
+  @Override
+  public void it(String testName) {
+    throw new SpecException("Cannot call it(\""+testName+"\") during the execution of a test");
+  }
+
+  @Override
+  public void xit(String testName, Runnable aTestCode) {
+    throw new SpecException("Cannot call xit(\""+testName+"\") during the execution of a test");
+  }
+
+  @Override
+  public void describe(String aGroupName, Runnable aGroupDefinition) {
+    throw new SpecException("Cannot call describe(\""+aGroupName+"\") during the execution of a test");
+  }
+
+  @Override
+  public void xdescribe(String aGroupName, Runnable aGroupDefinition) {
+    throw new SpecException("Cannot call xdescribe(\""+aGroupName+"\") during the execution of a test");
+  }
+
+  @Override
+  public T context() {
+    return definitionInterpreter.context();
+  }
+
+  public static<T extends TestContext> ExecutionInterpreter<T> create(DefinitionInterpreter<T> definitionInterpreter){
+    ExecutionInterpreter<T> executionInterpreter = new ExecutionInterpreter<>();
+    executionInterpreter.definitionInterpreter = definitionInterpreter;
+    return executionInterpreter;
+  }
+}

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/parser/SpecInterpreter.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/parser/SpecInterpreter.java
@@ -1,0 +1,125 @@
+package ar.com.dgarcia.javaspec.impl.parser;
+
+import ar.com.dgarcia.javaspec.api.JavaSpec;
+import ar.com.dgarcia.javaspec.api.JavaSpecApi;
+import ar.com.dgarcia.javaspec.api.TestContext;
+import ar.com.dgarcia.javaspec.api.Variable;
+import ar.com.dgarcia.javaspec.impl.context.typed.TypedContextFactory;
+import ar.com.dgarcia.javaspec.impl.exceptions.SpecException;
+import ar.com.dgarcia.javaspec.impl.model.SpecGroup;
+import ar.com.dgarcia.javaspec.impl.model.SpecTree;
+import ar.com.dgarcia.javaspec.impl.model.impl.GroupSpecDefinition;
+import ar.com.dgarcia.javaspec.impl.model.impl.SpecTreeDefinition;
+import ar.com.dgarcia.javaspec.impl.model.impl.TestSpecDefinition;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+/**
+ * This type represents the interpreter that builds the spec tree when api methods are called,
+ * interpreting the users input as test specificiations
+ *
+ * Created by tenpines on 31/12/15.
+ */
+public class SpecInterpreter<T extends TestContext> implements JavaSpecApi<T> {
+
+  private SpecTreeDefinition specTree;
+  private Variable<TestContext> sharedContext;
+  private SpecStack stack;
+  private T typedContext;
+  private Class<?> specClass;
+
+  public static<T extends TestContext> SpecInterpreter<T> create(Class<?> specClass){
+    SpecInterpreter<T> interpreter = new SpecInterpreter<>();
+    interpreter.specClass = specClass;
+    interpreter.initialize();
+    return interpreter;
+  }
+
+  private void initialize() {
+    this.specTree =  SpecTreeDefinition.create(specClass);
+
+    this.sharedContext = Variable.create();
+    SpecGroup rootGroup = specTree.getRootGroup();
+    this.stack = SpecStack.create(rootGroup, sharedContext);
+
+    Class<T> expectedContextType = this.getContextTypeFromSubclassDeclaration();
+    this.typedContext = TypedContextFactory.createInstanceOf(expectedContextType, sharedContext);
+  }
+
+  @Override
+  public void beforeEach(Runnable aCodeBlock) {
+    stack.getCurrentGroup().addBeforeBlock(aCodeBlock);
+  }
+
+  @Override
+  public void afterEach(Runnable aCodeBlock) {
+    stack.getCurrentGroup().addAfterBlock(aCodeBlock);
+  }
+
+  @Override
+  public void it(String testName, Runnable aTestCode){
+    addTestDefinition(testName, Optional.of(aTestCode));
+  }
+
+  @Override
+  public void it(String testName){
+    addTestDefinition(testName, Optional.empty());
+  }
+
+  @Override
+  public void xit(String testName, Runnable aTestCode){
+    TestSpecDefinition createdTestDefinition = addTestDefinition(testName, Optional.of(aTestCode));
+    createdTestDefinition.markAsPending();
+  }
+
+  private TestSpecDefinition addTestDefinition(String testName, Optional<Runnable> testBody) {
+    TestSpecDefinition createdSpec = TestSpecDefinition.create(testName, testBody, sharedContext);
+    stack.getCurrentGroup().addSubElement(createdSpec);
+    return createdSpec;
+  }
+
+
+  @Override
+  public void describe(String aGroupName, Runnable aGroupDefinition){
+    nestGroupDefinition(aGroupName, aGroupDefinition);
+  }
+
+  @Override
+  public void xdescribe(String aGroupName, Runnable aGroupDefinition){
+    GroupSpecDefinition createdGroup = nestGroupDefinition(aGroupName, aGroupDefinition);
+    createdGroup.markAsDisabled();
+  }
+
+  private GroupSpecDefinition nestGroupDefinition(String aGroupName, Runnable definitionBlock) {
+    GroupSpecDefinition createdGroup = GroupSpecDefinition.create(aGroupName);
+    stack.runNesting(createdGroup, definitionBlock::run);
+    return createdGroup;
+  }
+
+  @Override
+  public T context() {
+    return typedContext;
+  }
+
+  public SpecTree getSpecTree() {
+    return specTree;
+  }
+
+  public Class<T> getContextTypeFromSubclassDeclaration() {
+    if(!(specClass.getSuperclass().equals(JavaSpec.class))){
+      throw new SpecException("A java spec class["+ specClass + "] must inherit directly from " +JavaSpec.class);
+    }
+    Type generifiedJavaSpec = specClass.getGenericSuperclass();
+    if(!(generifiedJavaSpec instanceof ParameterizedType)){
+      throw new SpecException("JavaSpec superclass must be generified with a type of TestContext. For example JavaSpec<TestContext>");
+    }
+    Type contextType = ((ParameterizedType) generifiedJavaSpec).getActualTypeArguments()[0];
+    if(!(contextType instanceof Class)){
+      throw new SpecException("JavaSpec parameter is not a class?");
+    }
+    return (Class<T>) contextType;
+  }
+
+}

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/parser/SpecParser.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/parser/SpecParser.java
@@ -1,6 +1,8 @@
 package ar.com.dgarcia.javaspec.impl.parser;
 
 import ar.com.dgarcia.javaspec.api.JavaSpec;
+import ar.com.dgarcia.javaspec.api.JavaSpecRunner;
+import ar.com.dgarcia.javaspec.api.JavaSpecTestable;
 import ar.com.dgarcia.javaspec.impl.exceptions.SpecException;
 import ar.com.dgarcia.javaspec.impl.model.SpecTree;
 
@@ -15,19 +17,34 @@ public class SpecParser {
         return parser;
     }
 
-    public SpecTree parse(Class<? extends JavaSpec> specClass) {
-        JavaSpec specClassDefinition = instantiate(specClass);
-        SpecTree createdTree = specClassDefinition.defineTree();
+    public SpecTree parse(Class<?> specClass) throws IllegalArgumentException {
+        // Usage validation check
+        if(!JavaSpecTestable.class.isAssignableFrom(specClass)) {
+            throw new IllegalArgumentException("Your class["+specClass+"] must extend " + JavaSpec.class + " or implement "+JavaSpecTestable.class+" to be run with " +  JavaSpecRunner.class.getSimpleName());
+        }
+        JavaSpecTestable specInstance = instantiate((Class<? extends JavaSpecTestable>) specClass);
+        return interpretUserCalls(specInstance);
+    }
+
+  /**
+   * Generates a tree of specs interpreted out of the user calls to our api methods.<br>
+   *   Nested method calls generate groups of test, that end up in branches of the tree
+   * @param specInstance The spec definition object defined by user code
+   * @return The tree interpretation of the tests
+   */
+    private SpecTree interpretUserCalls(JavaSpecTestable specInstance) {
+        DefinitionInterpreter definitionInterpreter = DefinitionInterpreter.create(specInstance.getClass());
+        specInstance.defineSpecs(definitionInterpreter);
+        SpecTree createdTree = definitionInterpreter.getSpecTree();
         return createdTree;
     }
 
     /**
      * Creates the new instance using reflection on niladic constructor
      */
-    private JavaSpec instantiate(Class<? extends JavaSpec> specClass) {
+    private JavaSpecTestable instantiate(Class<? extends JavaSpecTestable> specClass) {
         try {
-            JavaSpec createdInstance = specClass.newInstance();
-            return createdInstance;
+            return specClass.newInstance();
         } catch( SecurityException e){
             throw new SpecException("Security forbids instantiation for spec["+specClass+"]",e);
         } catch( ExceptionInInitializerError e){

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/parser/SpecParser.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/parser/SpecParser.java
@@ -3,7 +3,6 @@ package ar.com.dgarcia.javaspec.impl.parser;
 import ar.com.dgarcia.javaspec.api.JavaSpec;
 import ar.com.dgarcia.javaspec.impl.exceptions.SpecException;
 import ar.com.dgarcia.javaspec.impl.model.SpecTree;
-import ar.com.dgarcia.javaspec.impl.model.impl.SpecTreeDefinition;
 
 /**
  * This type defines the parser that understands the definition of a JavaSpec subclass, and creates a model of the specs
@@ -17,9 +16,8 @@ public class SpecParser {
     }
 
     public SpecTree parse(Class<? extends JavaSpec> specClass) {
-        JavaSpec createdSpec = instantiate(specClass);
-        SpecTree createdTree = SpecTreeDefinition.create();
-        createdSpec.populate(createdTree);
+        JavaSpec specClassDefinition = instantiate(specClass);
+        SpecTree createdTree = specClassDefinition.defineTree();
         return createdTree;
     }
 

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/parser/SpecParser.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/parser/SpecParser.java
@@ -17,8 +17,8 @@ public class SpecParser {
     }
 
     public SpecTree parse(Class<? extends JavaSpec> specClass) {
-        SpecTree createdTree = SpecTreeDefinition.create();
         JavaSpec createdSpec = instantiate(specClass);
+        SpecTree createdTree = SpecTreeDefinition.create();
         createdSpec.populate(createdTree);
         return createdTree;
     }

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/parser/SpecStack.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/parser/SpecStack.java
@@ -3,6 +3,7 @@ package ar.com.dgarcia.javaspec.impl.parser;
 import ar.com.dgarcia.javaspec.api.TestContext;
 import ar.com.dgarcia.javaspec.api.Variable;
 import ar.com.dgarcia.javaspec.impl.model.SpecGroup;
+import ar.com.dgarcia.javaspec.impl.model.TestContextDefinition;
 import ar.com.dgarcia.javaspec.impl.model.impl.GroupSpecDefinition;
 
 import java.util.LinkedList;
@@ -24,9 +25,12 @@ public class SpecStack {
         return stack;
     }
 
-    private void push(SpecGroup group) {
-        this.nestedGroups.push(group);
-        this.updateContext();
+    /**
+     * Returns the current head of the stack
+     * @return The group that represents the current active group
+     */
+    public SpecGroup getCurrentGroup() {
+        return this.nestedGroups.peek();
     }
 
     /**
@@ -35,32 +39,32 @@ public class SpecStack {
      * @param newHead The group to used a stack head
      * @param code The code to execute with the newHead
      */
-    public void executeAsCurrent(GroupSpecDefinition newHead, Runnable code) {
-        this.push(newHead);
-        try{
-            code.run();
-        }finally {
-            this.pop();
-        }
+    public void runNesting(GroupSpecDefinition newHead, Runnable code) {
+      this.getCurrentGroup().addSubGroup(newHead);
+      this.push(newHead);
+      try{
+          code.run();
+      }finally {
+          this.pop();
+      }
+    }
+
+    private void push(SpecGroup group) {
+        this.nestedGroups.push(group);
+        this.updateCurrentContext();
     }
 
     /**
      * Grabs the context from current head and sets that as current context
      */
-    private void updateContext() {
-        currentContext.set(getCurrentHead().getTestContext());
+    private void updateCurrentContext() {
+        TestContextDefinition currentGroupContext = getCurrentGroup().getTestContext();
+        currentContext.set(currentGroupContext);
     }
 
     private void pop() {
         this.nestedGroups.pop();
-        this.updateContext();
+        this.updateCurrentContext();
     }
 
-    /**
-     * Returns the current head of the stack
-     * @return The group that represents the current active group
-     */
-    public SpecGroup getCurrentHead() {
-        return this.nestedGroups.peek();
-    }
 }

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/parser/SpecStack.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/parser/SpecStack.java
@@ -40,7 +40,7 @@ public class SpecStack {
      * @param code The code to execute with the newHead
      */
     public void runNesting(GroupSpecDefinition newHead, Runnable code) {
-      this.getCurrentGroup().addSubGroup(newHead);
+      this.getCurrentGroup().addSubElement(newHead);
       this.push(newHead);
       try{
           code.run();

--- a/src/test/java/ar/com/dgarcia/javaspec/JasmineWithoutInheritanceExampleTest.java
+++ b/src/test/java/ar/com/dgarcia/javaspec/JasmineWithoutInheritanceExampleTest.java
@@ -1,0 +1,176 @@
+package ar.com.dgarcia.javaspec;
+
+import ar.com.dgarcia.javaspec.api.*;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * This class serves as an example of Java-Spec without using inheritance to define the spec.<br>
+ * Based on http://jasmine.github.io/2.0/introduction.html
+ * Created by kfgodel on 12/07/14.
+ */
+@RunWith(JavaSpecRunner.class)
+public class JasmineWithoutInheritanceExampleTest implements JavaSpecTestable<TestContext> {
+
+  private Variable<Integer> foo = new Variable<>();
+  private Variable<String> bar = new Variable<>();
+
+  public void defineSpecs(JavaSpecApi<TestContext> spec) {
+
+    // introduction.js
+    spec.describe("A suite", () -> {
+      spec.it("contains spec with an expectation", () -> {
+        assertThat(true).isEqualTo(true);
+      });
+    });
+
+
+    // It’s Just Functions
+    spec.describe("A suite is just a lambda", () -> {
+
+      Variable<Boolean> a = Variable.create();
+
+      spec.it("and so is a spec", () -> {
+        a.set(true);
+
+        assertThat(a.get()).isEqualTo(true);
+      });
+    });
+
+
+    // Expectations
+    spec.describe("AssertJ assertions can be used in the spec", () -> {
+
+      spec.it("and has a positive case", () -> {
+        assertThat(true).isEqualTo(true);
+      });
+
+      spec.it("and can have a negative case", () -> {
+        assertThat(false).isNotEqualTo(true);
+      });
+    });
+
+
+    // Setup and Teardown
+    spec.describe("A spec (with setup and tear-down)", () -> {
+      Variable<Integer> foo = Variable.create();
+
+      spec.beforeEach(() -> {
+        foo.set(0);
+        foo.storeSumWith(1);
+      });
+
+      spec.afterEach(() -> {
+        foo.set(0);
+      });
+
+      spec.it("is just a lambda, so it can contain any code", () -> {
+        assertThat(foo.get()).isEqualTo(1);
+      });
+
+      spec.it("can have more than one expectation", () -> {
+        assertThat(foo.get()).isEqualTo(1);
+        assertThat(true).isEqualTo(true);
+      });
+
+    });
+
+
+    spec.describe("A spec", () -> {
+      Variable<Integer> foo = new Variable<>();
+
+      spec.beforeEach(() -> {
+        foo.set(0);
+        foo.storeSumWith(1);
+      });
+
+      spec.afterEach(() -> {
+        foo.set(0);
+      });
+
+      spec.it("is just a lambda, so it can contain any code", () -> {
+        assertThat(foo.get()).isEqualTo(1);
+      });
+
+      spec.it("can have more than one expectation", () -> {
+        assertThat(foo.get()).isEqualTo(1);
+        assertThat(true).isTrue();
+      });
+
+      spec.describe("nested inside a second describe", () -> {
+        Variable<Integer> bar = new Variable<>();
+
+        spec.beforeEach(() -> {
+          bar.set(1);
+        });
+
+        spec.it("can reference both scopes as needed", () -> {
+          assertThat(foo.get()).isEqualTo(bar.get());
+        });
+      });
+    });
+
+
+    // The this keyword
+    spec.describe("A spec", () -> {
+      spec.beforeEach(() -> {
+        this.foo.set(0);
+      });
+
+      spec.it("that use `this` to share state", () -> {
+        assertThat(foo.get()).isEqualTo(0);
+        this.bar.set("test pollution?");
+      });
+
+      spec.it("will have test pollution by sharing the host instance", () -> {
+        assertThat(foo.get()).isEqualTo(0);
+        assertThat(bar.get()).isEqualTo("test pollution?");
+      });
+    });
+
+
+    // Disabling Suites
+    spec.xdescribe("A disabled group spec", () -> {
+
+      spec.it("disabled implicitly", () -> {
+        assertThat(foo.get()).isEqualTo(1);
+      });
+
+      spec.xit("disabled explicitly", () -> {
+        assertThat(foo.get()).isEqualTo(2);
+      });
+    });
+
+
+    // Pending Specs
+    spec.describe("Pending specs", () -> {
+
+      spec.xit("can be declared 'xit'", () -> {
+        assertThat(true).isEqualTo(false);
+      });
+
+      spec.it("can be declared with 'it' but without a lambda");
+
+    });
+
+
+    // Spies
+    spec.describe("has spies with mockito", () -> {
+
+      spec.it("use mockito as usuarl", () -> {
+        List<String> mockedList = mock(List.class);
+        when(mockedList.get(0)).thenReturn("First");
+
+        assertThat(mockedList.get(0)).isEqualTo("First");
+      });
+
+    });
+
+  }
+
+}

--- a/src/test/java/ar/com/dgarcia/javaspec/SpecParserTest.java
+++ b/src/test/java/ar/com/dgarcia/javaspec/SpecParserTest.java
@@ -83,12 +83,12 @@ public class SpecParserTest {
         SpecTest firstTest = declaredTest.get(0);
         assertThat(firstTest.getName()).isEqualTo("xit pending test");
         assertThat(firstTest.isMarkedAsPending()).isTrue();
-        assertThat(firstTest.getTestCode()).isNotNull();
+        assertThat(firstTest.getTestBodyCode().isPresent()).isTrue();
 
         SpecTest secondTest = declaredTest.get(1);
         assertThat(secondTest.getName()).isEqualTo("non lambda pending test");
         assertThat(secondTest.isMarkedAsPending()).isTrue();
-        assertThat(secondTest.getTestCode()).isNull();
+        assertThat(secondTest.getTestBodyCode().isPresent()).isFalse();
     }
 
     @Test

--- a/src/test/java/ar/com/dgarcia/javaspec/junit/JunitTestCodeRunnableTest.java
+++ b/src/test/java/ar/com/dgarcia/javaspec/junit/JunitTestCodeRunnableTest.java
@@ -1,11 +1,7 @@
 package ar.com.dgarcia.javaspec.junit;
 
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
+import ar.com.dgarcia.javaspec.impl.junit.JunitIgnoredTestCode;
+import ar.com.dgarcia.javaspec.impl.junit.JunitRunnableTestCode;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.internal.AssumptionViolatedException;
@@ -14,25 +10,29 @@ import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 import org.mockito.ArgumentMatcher;
 
-import ar.com.dgarcia.javaspec.impl.junit.JunitTestCode;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.*;
 
 /**
  * This type verifyes that JunitTestCode behaves as expected to junit
  * Created by kfgodel on 13/07/14.
  */
-public class JunitTestCodeTest {
+public class JunitTestCodeRunnableTest {
 
     private RunNotifier mockedNotifier;
     private Description mockedDescription;
     private Runnable mockedCode;
-    private JunitTestCode junitTest;
+    private JunitRunnableTestCode junitTest;
+    private JunitIgnoredTestCode ignoredJunitTest;
 
     @Before
     public void prepareTestDoubles(){
         mockedNotifier = mock(RunNotifier.class);
         mockedDescription = mock(Description.class);
         mockedCode = mock(Runnable.class);
-        junitTest = JunitTestCode.create(mockedCode, mockedDescription);
+        junitTest = JunitRunnableTestCode.create(mockedCode, mockedDescription);
+        ignoredJunitTest = JunitIgnoredTestCode.create(mockedDescription);
     }
 
     @Test
@@ -79,12 +79,7 @@ public class JunitTestCodeTest {
 
     @Test
     public void notifiesWhenTestIsIgnored(){
-        doAnswer(invocationOnMock -> {
-            throw new RuntimeException("Shouldn't execute");
-        }).when(mockedCode).run();
-
-        junitTest.ignoreTest();
-        junitTest.executeNotifying(mockedNotifier);
+        ignoredJunitTest.executeNotifying(mockedNotifier);
 
         verify(mockedNotifier).fireTestIgnored(mockedDescription);
     }

--- a/src/test/java/ar/com/dgarcia/javaspec/junit/JunitTestTreeAdapterTest.java
+++ b/src/test/java/ar/com/dgarcia/javaspec/junit/JunitTestTreeAdapterTest.java
@@ -26,7 +26,7 @@ public class JunitTestTreeAdapterTest {
         Class<? extends JavaSpec> specClass = EmptySpec.class;
         SpecTree specTree = SpecParser.create().parse(specClass);
 
-        JunitTestTreeAdapter adapter = JunitTestTreeAdapter.create(specTree, specClass);
+        JunitTestTreeAdapter adapter = JunitTestTreeAdapter.create(specTree);
         assertThat(adapter.getJunitTree().getJunitDescription().getDisplayName()).isEqualTo(specClass.getName());
     }
 
@@ -35,7 +35,7 @@ public class JunitTestTreeAdapterTest {
         Class<? extends JavaSpec> specClass = OneEmptyDescribeSpec.class;
         SpecTree specTree = SpecParser.create().parse(specClass);
 
-        JunitTestTreeAdapter adapter = JunitTestTreeAdapter.create(specTree, specClass);
+        JunitTestTreeAdapter adapter = JunitTestTreeAdapter.create(specTree);
         Description onlySubGroup = adapter.getJunitTree().getJunitDescription().getChildren().get(0);
         assertThat(onlySubGroup.getDisplayName()).isEqualTo("empty describe");
 
@@ -46,7 +46,7 @@ public class JunitTestTreeAdapterTest {
         Class<? extends JavaSpec> specClass = OneRootTestSpecTest.class;
         SpecTree specTree = SpecParser.create().parse(specClass);
 
-        JunitTestTreeAdapter adapter = JunitTestTreeAdapter.create(specTree, specClass);
+        JunitTestTreeAdapter adapter = JunitTestTreeAdapter.create(specTree);
         List<JunitTestCode> junitTests = adapter.getJunitTree().getJunitTests();
         assertThat(junitTests).hasSize(1);
         assertThat(junitTests.get(0).getTestDescription().getDisplayName()).isEqualTo("only test");

--- a/src/test/java/ar/com/dgarcia/javaspec/junit/JunitTestTreeTest.java
+++ b/src/test/java/ar/com/dgarcia/javaspec/junit/JunitTestTreeTest.java
@@ -1,14 +1,13 @@
 package ar.com.dgarcia.javaspec.junit;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-
+import ar.com.dgarcia.javaspec.impl.junit.JunitTestCode;
+import ar.com.dgarcia.javaspec.impl.junit.JunitTestTree;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.Description;
 
-import ar.com.dgarcia.javaspec.impl.junit.JunitTestCode;
-import ar.com.dgarcia.javaspec.impl.junit.JunitTestTree;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * This type verifies that the JunitTestTree behaves as expected

--- a/src/test/java/ar/com/dgarcia/javaspec/testSpecs/SpecDefinitionCannotChangeDuringTestRunTest.java
+++ b/src/test/java/ar/com/dgarcia/javaspec/testSpecs/SpecDefinitionCannotChangeDuringTestRunTest.java
@@ -1,0 +1,43 @@
+package ar.com.dgarcia.javaspec.testSpecs;
+
+import ar.com.dgarcia.javaspec.api.JavaSpec;
+import ar.com.dgarcia.javaspec.api.JavaSpecRunner;
+import ar.com.dgarcia.javaspec.api.TestContext;
+import ar.com.dgarcia.javaspec.impl.exceptions.SpecException;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+/**
+ * Created by tenpines on 31/12/15.
+ */
+@RunWith(JavaSpecRunner.class)
+public class SpecDefinitionCannotChangeDuringTestRunTest extends JavaSpec<TestContext> {
+
+  @Override
+  public void define() {
+    describe("during the execution of a test", ()->{
+
+      it("another test cannot be defined", () -> {
+
+        try{
+          it("another test", ()->{});
+          failBecauseExceptionWasNotThrown(SpecException.class);
+        }catch (SpecException e){
+          assertThat(e).hasMessage("Cannot call it(\"another test\") during the execution of a test");
+        }
+
+      });
+
+      it("another group cannot be defined", () -> {
+        try{
+          describe("another group", ()->{});
+          failBecauseExceptionWasNotThrown(SpecException.class);
+        }catch (SpecException e){
+          assertThat(e).hasMessage("Cannot call describe(\"another group\") during the execution of a test");
+        }
+      });
+    });
+  }
+}


### PR DESCRIPTION
- Refactored logic to make it more understandable
- Extracted logic from class JavaSpec to not depend on inheritance
- Added Interpreter to hold the extracted logic
- Allow different use case using interfaces instead of inheritance to define tests