### PR TITLE
Null as value

### DIFF
--- a/src/main/java/ar/com/dgarcia/javaspec/impl/DefinitionMode.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/DefinitionMode.java
@@ -71,7 +71,7 @@ public class DefinitionMode<T extends TestContext> implements JavaSpecApi<T> {
         if(expectedExceptionType.isAssignableFrom(e.getClass())){
           exceptionAssertions.accept((X) e);
         }else{
-          throw new AssertionError("Expection an exception of type: " + expectedTypeName + " but caught a different: " + e, e);
+          throw new AssertionError("Expecting " + expectedTypeName + " but caught: " + e, e);
         }
       }
     };

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/context/MappedContext.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/context/MappedContext.java
@@ -82,12 +82,8 @@ public class MappedContext implements TestContextDefinition, ClassBasedTestConte
       T variableValue = variableDefinition.get();
       storeValueFor(variableName, variableValue);
       return variableValue;
-    } catch (SpecException e) {
-      throw e;
     } catch (StackOverflowError e) {
       throw new SpecException("Got a Stackoverflow when evaluating variable [" + variableName + "]. Do we have a cyclic dependency on its definition?", e);
-    } catch (Exception e) {
-      throw new SpecException("Definition for variable [" + variableName + "] failed to execute: " + e.getMessage(), e);
     }
   }
 

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/context/MappedContext.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/context/MappedContext.java
@@ -42,7 +42,7 @@ public class MappedContext implements TestContextDefinition, ClassBasedTestConte
 
     Optional<Supplier<T>> variableDefinition = (Optional) getDefinitionFor(variableName);
     if (!variableDefinition.isPresent()) {
-      throw new SpecException("Variable [" + variableName + "] cannot be accessed because it lacks a definition in this context[" + this.getVariableDefinitions() + "]");
+      throw new SpecException("Variable [" + variableName + "] must be defined before accessing it in current context[" + this.getVariableDefinitions() + "]");
     }
     return this.createNewValueFrom(variableDefinition.get(), variableName);
   }

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/context/MappedContext.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/context/MappedContext.java
@@ -41,9 +41,10 @@ public class MappedContext implements TestContextDefinition, ClassBasedTestConte
     }
 
     Optional<Supplier<T>> variableDefinition = (Optional) getDefinitionFor(variableName);
-    return variableDefinition
-      .map((definition) -> this.createNewValueFrom(definition, variableName))
-      .orElseThrow(()-> new SpecException("Variable [" + variableName + "] cannot be accessed because it lacks a definition in this context[" + this.getVariableDefinitions() + "]"));
+    if (!variableDefinition.isPresent()) {
+      throw new SpecException("Variable [" + variableName + "] cannot be accessed because it lacks a definition in this context[" + this.getVariableDefinitions() + "]");
+    }
+    return this.createNewValueFrom(variableDefinition.get(), variableName);
   }
 
   @Override

--- a/src/test/java/ar/com/dgarcia/javaspec/GivenWhenThenSpecTest.java
+++ b/src/test/java/ar/com/dgarcia/javaspec/GivenWhenThenSpecTest.java
@@ -56,7 +56,7 @@ public class GivenWhenThenSpecTest extends JavaSpec<GiveWhenThenTestContext> {
           });
           failBecauseExceptionWasNotThrown(SpecException.class);
         }catch (SpecException e){
-          assertThat(e.getMessage()).startsWith("Variable [setupCode] cannot be accessed because it lacks a definition in this context");
+          assertThat(e.getMessage()).startsWith("Variable [setupCode] must be defined before accessing it in current context");
         }
       });
       it("throws an error if the exercise code is not defined",()->{
@@ -69,7 +69,7 @@ public class GivenWhenThenSpecTest extends JavaSpec<GiveWhenThenTestContext> {
           });
           failBecauseExceptionWasNotThrown(SpecException.class);
         }catch (SpecException e){
-          assertThat(e.getMessage()).startsWith("Variable [exerciseCode] cannot be accessed because it lacks a definition in this context");
+          assertThat(e.getMessage()).startsWith("Variable [exerciseCode] must be defined before accessing it in current context");
         }
       });
       it("throws an error if the assertion code is not defined", () -> {
@@ -83,7 +83,7 @@ public class GivenWhenThenSpecTest extends JavaSpec<GiveWhenThenTestContext> {
           executeAsGivenWhenThenTest();
           failBecauseExceptionWasNotThrown(SpecException.class);
         }catch (SpecException e){
-          assertThat(e.getMessage()).startsWith("Variable [assertionCode] cannot be accessed because it lacks a definition in this context");
+          assertThat(e.getMessage()).startsWith("Variable [assertionCode] must be defined before accessing it in current context");
         }
       });
 

--- a/src/test/java/ar/com/dgarcia/javaspec/ManualGWTContextManagementTest.java
+++ b/src/test/java/ar/com/dgarcia/javaspec/ManualGWTContextManagementTest.java
@@ -26,7 +26,7 @@ public class ManualGWTContextManagementTest extends JavaSpec<TestContext> {
             context().setupCode();
             failBecauseExceptionWasNotThrown(SpecException.class);
           } catch (SpecException e) {
-            assertThat(e).hasMessage("Variable [setupCode] cannot be accessed because it lacks a definition in this context[{}]");
+            assertThat(e).hasMessage("Variable [setupCode] must be defined before accessing it in current context[{}]");
           }
         });
         it("throws an exception when the exercise code is accessed", () -> {
@@ -34,7 +34,7 @@ public class ManualGWTContextManagementTest extends JavaSpec<TestContext> {
             context().exerciseCode();
             failBecauseExceptionWasNotThrown(SpecException.class);
           } catch (SpecException e) {
-            assertThat(e).hasMessage("Variable [exerciseCode] cannot be accessed because it lacks a definition in this context[{}]");
+            assertThat(e).hasMessage("Variable [exerciseCode] must be defined before accessing it in current context[{}]");
           }
         });
         it("throws an exception when the assertion code is accessed", () -> {
@@ -42,7 +42,7 @@ public class ManualGWTContextManagementTest extends JavaSpec<TestContext> {
             context().assertionCode();
             failBecauseExceptionWasNotThrown(SpecException.class);
           } catch (SpecException e) {
-            assertThat(e).hasMessage("Variable [assertionCode] cannot be accessed because it lacks a definition in this context[{}]");
+            assertThat(e).hasMessage("Variable [assertionCode] must be defined before accessing it in current context[{}]");
           }
         });
       });

--- a/src/test/java/ar/com/dgarcia/javaspec/TestContextDefinitionTest.java
+++ b/src/test/java/ar/com/dgarcia/javaspec/TestContextDefinitionTest.java
@@ -56,14 +56,14 @@ public class TestContextDefinitionTest {
     }
 
     @Test
-    public void itThrowsAnExceptionIfVariableDefinitionFails(){
+    public void itForwardsTheOriginalExceptionIfVariableDefinitionFails() {
         testContext.let("explosion", ()-> { throw new RuntimeException("Boom!"); } );
 
         try{
             testContext.get("explosion");
-            failBecauseExceptionWasNotThrown(SpecException.class);
-        }catch(SpecException e){
-            assertThat(e).hasMessage("Definition for variable [explosion] failed to execute: Boom!");
+            failBecauseExceptionWasNotThrown(RuntimeException.class);
+        } catch (RuntimeException e) {
+            assertThat(e).hasMessage("Boom!");
         }
     }
 

--- a/src/test/java/ar/com/dgarcia/javaspec/TestContextDefinitionTest.java
+++ b/src/test/java/ar/com/dgarcia/javaspec/TestContextDefinitionTest.java
@@ -51,7 +51,7 @@ public class TestContextDefinitionTest {
             testContext.get("undefined");
             failBecauseExceptionWasNotThrown(SpecException.class);
         }catch(SpecException e){
-            assertThat(e).hasMessage("Variable [undefined] cannot be accessed because it lacks a definition in this context[{}]");
+            assertThat(e).hasMessage("Variable [undefined] must be defined before accessing it in current context[{}]");
         }
     }
 

--- a/src/test/java/ar/com/dgarcia/javaspec/testSpecs/UseNullAsValidValueTest.java
+++ b/src/test/java/ar/com/dgarcia/javaspec/testSpecs/UseNullAsValidValueTest.java
@@ -3,6 +3,7 @@ package ar.com.dgarcia.javaspec.testSpecs;
 import ar.com.dgarcia.javaspec.api.JavaSpec;
 import ar.com.dgarcia.javaspec.api.JavaSpecRunner;
 import ar.com.dgarcia.javaspec.api.contexts.TestContext;
+import ar.com.dgarcia.javaspec.api.exceptions.SpecException;
 import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,5 +24,10 @@ public class UseNullAsValidValueTest extends JavaSpec<TestContext> {
       });
     });
 
+    itThrows(SpecException.class, "when the variable is not defined and accessed", () -> {
+      context().get("undefinedVariable");
+    }, e -> {
+      assertThat(e).hasMessage("Variable [undefinedVariable] must be defined before accessing it in current context[{}]");
+    });
   }
 }

--- a/src/test/java/ar/com/dgarcia/javaspec/testSpecs/UseNullAsValidValueTest.java
+++ b/src/test/java/ar/com/dgarcia/javaspec/testSpecs/UseNullAsValidValueTest.java
@@ -1,0 +1,27 @@
+package ar.com.dgarcia.javaspec.testSpecs;
+
+import ar.com.dgarcia.javaspec.api.JavaSpec;
+import ar.com.dgarcia.javaspec.api.JavaSpecRunner;
+import ar.com.dgarcia.javaspec.api.contexts.TestContext;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This test verifies that null can be defined as a valid value for a context variable
+ * Date: 17/12/18 - 23:09
+ */
+@RunWith(JavaSpecRunner.class)
+public class UseNullAsValidValueTest extends JavaSpec<TestContext> {
+  @Override
+  public void define() {
+    describe("a null valued variable", () -> {
+      context().let("aVariable", () -> null);
+
+      it("can be used on tests", () -> {
+        assertThat(context().<Object>get("aVariable")).isNull();
+      });
+    });
+
+  }
+}


### PR DESCRIPTION
- Allow usage of null as variable value.
- Make original exception travel to caller