### PR TITLE
Local Lets support for Kotlin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,11 +51,14 @@
       <version>${version.assertj}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-jdk8</artifactId>
       <version>${version.kotlin}</version>
+      <optional>true</optional>
     </dependency>
+    
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-test-junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
   <properties>
     <version.junit>4.11</version.junit>
     <version.assertj>3.11.1</version.assertj>
+    <version.kotlin>1.3.31</version.kotlin>
   </properties>
 
   <dependencies>
@@ -50,8 +51,74 @@
       <version>${version.assertj}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>${version.kotlin}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-test-junit</artifactId>
+      <version>${version.kotlin}</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${version.kotlin}</version>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+            <configuration>
+              <sourceDirs>
+                <source>src/test/java</source>
+                <source>src/test/kotlin</source>
+              </sourceDirs>
+            </configuration>
+          </execution>
+        </executions>
+        <configuration>
+          <jvmTarget>1.8</jvmTarget>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>testCompile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
   <developers>
     <developer>

--- a/src/main/java/ar/com/dgarcia/javaspec/api/variable/Let.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/api/variable/Let.java
@@ -26,7 +26,7 @@ public class Let<T> {
    *
    * @param definition A value supplier that can be used to lazily define the initial value of the variable
    */
-  public <U extends T> Let<U> set(Supplier<T> definition) {
+  public <U extends T> Let<U> let(Supplier<T> definition) {
     context().let(variableName(), definition);
     return (Let<U>) this;
   }

--- a/src/main/java/ar/com/dgarcia/javaspec/api/variable/Let.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/api/variable/Let.java
@@ -42,11 +42,11 @@ public class Let<T> {
     return context().get(variableName());
   }
 
-  private String variableName() {
+  String variableName() {
     return variableName;
   }
 
-  private TestContext context() {
+  TestContext context() {
     return context.get();
   }
 

--- a/src/main/java/ar/com/dgarcia/javaspec/api/variable/LetExtensions.kt
+++ b/src/main/java/ar/com/dgarcia/javaspec/api/variable/LetExtensions.kt
@@ -1,0 +1,6 @@
+package ar.com.dgarcia.javaspec.api.variable
+
+fun <T> Let<T>.set(definition: () -> T): Let<T> {
+  context().let(variableName(), definition)
+  return Let.create(variableName()) { context() }
+}

--- a/src/test/java/ar/com/dgarcia/javaspec/testSpecs/LocalLetSpecTest.java
+++ b/src/test/java/ar/com/dgarcia/javaspec/testSpecs/LocalLetSpecTest.java
@@ -25,21 +25,21 @@ public class LocalLetSpecTest extends JavaSpec<TestContext> {
 
       describe("can be declared in suite contexts", () -> {
         Let<Integer> foo = localLet("foo");
-        Let<Integer> predefinedValue = localLet("predefinedValue").set(() -> 3);
+        Let<Integer> predefinedValue = localLet("predefinedValue").let(() -> 3);
 
         it("can have a value defined with its creation", () -> {
           assertThat(predefinedValue.get()).isEqualTo(3);
         });
 
         describe("and its value can be set in contexts", () -> {
-          foo.set(() -> 1);
+          foo.let(() -> 1);
 
           it("can obtain that value", () -> {
             assertThat(foo.get()).isEqualTo(1);
           });
 
           describe("when redefining its value in a sub-context", () -> {
-            foo.set(() -> 2);
+            foo.let(() -> 2);
 
             it("changes the original value", () -> {
               assertThat(foo.get()).isEqualTo(2);
@@ -49,7 +49,7 @@ public class LocalLetSpecTest extends JavaSpec<TestContext> {
         });
 
         it("and its value can also be set inside a test", ()->{
-          foo.set(() -> 3);
+          foo.let(() -> 3);
 
           assertThat(foo.get()).isEqualTo(3);
         });
@@ -63,11 +63,11 @@ public class LocalLetSpecTest extends JavaSpec<TestContext> {
       describe("definitions are prioritized", ()->{
 
         Let<Integer> foo = localLet("foo");
-        foo.set(()-> 1);
+        foo.let(()-> 1);
 
         beforeEach(()->{
           //This will override context definition
-          foo.set(()-> 2);
+          foo.let(()-> 2);
         });
 
         it("setup definition will have precedence over suite definition", ()->{
@@ -75,7 +75,7 @@ public class LocalLetSpecTest extends JavaSpec<TestContext> {
         });
 
         it("it definition has precedence over the other two", ()->{
-          foo.set(()-> 3);
+          foo.let(()-> 3);
 
           assertThat(foo.get()).isEqualTo(3);
         });
@@ -86,16 +86,16 @@ public class LocalLetSpecTest extends JavaSpec<TestContext> {
         Let<Integer> sum = localLet("sum");
         Let<Integer> value = localLet("value");
 
-        sum.set(()-> 2 + value.get());
+        sum.let(()-> 2 + value.get());
 
         it("allowing to change parts of the test context", ()->{
-          value.set(()-> 2);
+          value.let(()-> 2);
 
           assertThat(sum.get()).isEqualTo(4);
         });
 
         describe("or nesting scenarios", ()->{
-          value.set(()-> 1);
+          value.let(()-> 1);
 
           it("with cleanly defined context", ()->{
             assertThat(sum.get()).isEqualTo(3);
@@ -105,7 +105,7 @@ public class LocalLetSpecTest extends JavaSpec<TestContext> {
 
       describe("once defined", ()->{
         Let<Integer> random = localLet("random");
-        random.set(()-> new Random().nextInt());
+        random.let(()-> new Random().nextInt());
 
         it("the value remains the same through test duration", ()->{
           Integer firstTime = random.get();
@@ -118,9 +118,9 @@ public class LocalLetSpecTest extends JavaSpec<TestContext> {
         Let<Integer> value = localLet("value");
 
         it("it cannot be redefined", ()-> {
-          value.set(()-> 1);
+          value.let(()-> 1);
           value.get();
-          assertThatThrownBy(() -> value.set(()-> 2))
+          assertThatThrownBy(() -> value.let(()-> 2))
               .isInstanceOf(SpecException.class)
               .hasMessage("Variable [value] cannot be re-defined once assigned. Current value: [1]");
         });

--- a/src/test/kotlin/ar/com/dgarcia/javaspec/testSpecs/KotlinLocalLetSpecTest.kt
+++ b/src/test/kotlin/ar/com/dgarcia/javaspec/testSpecs/KotlinLocalLetSpecTest.kt
@@ -19,8 +19,8 @@ class KotlinLocalLetSpecTest : JavaSpec<TestContext>() {
     describe("local lets") {
 
       describe("can be declared in suite contexts") {
-        val foo: Let<Int> = localLet("foo")
-        val predefinedValue: Let<Int> = localLet<Int>("predefinedValue").set { 3 }
+        val foo = localLet<Int>("foo")
+        val predefinedValue = localLet<Int>("predefinedValue").set { 3 }
 
         it("can have a value defined with its creation") {
           assertThat(predefinedValue.get()).isEqualTo(3)
@@ -52,8 +52,8 @@ class KotlinLocalLetSpecTest : JavaSpec<TestContext>() {
 
       describe("one definition can use others") {
 
-        val sum: Let<Int> = localLet("sum")
-        val value: Let<Int> = localLet("value")
+        val sum = localLet<Int>("sum")
+        val value = localLet<Int>("value")
 
         sum.set { 2 + value.get() }
 

--- a/src/test/kotlin/ar/com/dgarcia/javaspec/testSpecs/KotlinLocalLetSpecTest.kt
+++ b/src/test/kotlin/ar/com/dgarcia/javaspec/testSpecs/KotlinLocalLetSpecTest.kt
@@ -1,0 +1,77 @@
+package ar.com.dgarcia.javaspec.testSpecs
+
+import ar.com.dgarcia.javaspec.api.JavaSpec
+import ar.com.dgarcia.javaspec.api.JavaSpecRunner
+import ar.com.dgarcia.javaspec.api.contexts.TestContext
+import ar.com.dgarcia.javaspec.api.variable.Let
+import ar.com.dgarcia.javaspec.api.variable.set
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.runner.RunWith
+
+/**
+ * This type tests usage of local lets in Kotlin
+ * Created by nrainhart on 11/05/19.
+ */
+@RunWith(JavaSpecRunner::class)
+class KotlinLocalLetSpecTest : JavaSpec<TestContext>() {
+
+  override fun define() {
+    describe("local lets") {
+
+      describe("can be declared in suite contexts") {
+        val foo: Let<Int> = localLet("foo")
+        val predefinedValue: Let<Int> = localLet<Int>("predefinedValue").set { 3 }
+
+        it("can have a value defined with its creation") {
+          assertThat(predefinedValue.get()).isEqualTo(3)
+        }
+
+        describe("and its value can be set in contexts") {
+          foo.set { 1 }
+
+          it("can obtain that value") {
+            assertThat(foo.get()).isEqualTo(1)
+          }
+
+          describe("when redefining its value in a sub-context") {
+            foo.set { 2 }
+
+            it("changes the original value") {
+              assertThat(foo.get()).isEqualTo(2)
+            }
+          }
+
+        }
+
+        it("and its value can also be set inside a test") {
+          foo.set { 3 }
+
+          assertThat(foo.get()).isEqualTo(3)
+        }
+      }
+
+      describe("one definition can use others") {
+
+        val sum: Let<Int> = localLet("sum")
+        val value: Let<Int> = localLet("value")
+
+        sum.set { 2 + value.get() }
+
+        it("allowing to change parts of the test context") {
+          value.set { 2 }
+
+          assertThat(sum.get()).isEqualTo(4)
+        }
+
+        describe("or nesting scenarios") {
+          value.set { 1 }
+
+          it("with cleanly defined context") { assertThat(sum.get()).isEqualTo(3) }
+        }
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
Renames JavaSpec's Let#set method to Let#let (intended to be used in Java applications), and adds Let#set extension method for Kotlin.