### PR TITLE
Refactor - Reify execution modes

### DIFF
--- a/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpec.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/api/JavaSpec.java
@@ -6,6 +6,7 @@ import ar.com.dgarcia.javaspec.api.exceptions.SpecException;
 import ar.com.dgarcia.javaspec.api.variable.Let;
 import ar.com.dgarcia.javaspec.impl.model.SpecTree;
 import ar.com.dgarcia.javaspec.impl.modes.DefinitionMode;
+import ar.com.dgarcia.javaspec.impl.modes.ExecutionMode;
 import ar.com.dgarcia.javaspec.impl.modes.InitialMode;
 
 import java.lang.reflect.ParameterizedType;
@@ -19,7 +20,7 @@ import java.util.function.Consumer;
  */
 public abstract class JavaSpec<T extends TestContext> implements JavaSpecApi<T> {
 
-  private JavaSpecApi<T> currentMode = InitialMode.create();
+  private ExecutionMode<T> currentMode = InitialMode.create();
 
   /**
    * Starting method to define the specs.<br>

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/modes/DefinitionMode.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/modes/DefinitionMode.java
@@ -1,6 +1,5 @@
 package ar.com.dgarcia.javaspec.impl.modes;
 
-import ar.com.dgarcia.javaspec.api.JavaSpecApi;
 import ar.com.dgarcia.javaspec.api.contexts.ClassBasedTestContext;
 import ar.com.dgarcia.javaspec.api.contexts.TestContext;
 import ar.com.dgarcia.javaspec.api.exceptions.FailingRunnable;
@@ -23,7 +22,7 @@ import java.util.function.Consumer;
  *
  * Created by kfgodel on 09/03/16.
  */
-public class DefinitionMode<T extends TestContext> implements JavaSpecApi<T> {
+public class DefinitionMode<T extends TestContext> implements ExecutionMode<T> {
 
   private SpecStack stack;
   private SpecTree specTree;

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/modes/ExecutionMode.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/modes/ExecutionMode.java
@@ -1,0 +1,7 @@
+package ar.com.dgarcia.javaspec.impl.modes;
+
+import ar.com.dgarcia.javaspec.api.JavaSpecApi;
+import ar.com.dgarcia.javaspec.api.contexts.TestContext;
+
+public interface ExecutionMode<T extends TestContext> extends JavaSpecApi<T> {
+}

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/modes/ExecutionMode.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/modes/ExecutionMode.java
@@ -3,5 +3,8 @@ package ar.com.dgarcia.javaspec.impl.modes;
 import ar.com.dgarcia.javaspec.api.JavaSpecApi;
 import ar.com.dgarcia.javaspec.api.contexts.TestContext;
 
+/**
+ * This type defines the contract that spec implementations can use during a specific stage of tests' execution
+ */
 public interface ExecutionMode<T extends TestContext> extends JavaSpecApi<T> {
 }

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/modes/InitialMode.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/modes/InitialMode.java
@@ -1,6 +1,5 @@
 package ar.com.dgarcia.javaspec.impl.modes;
 
-import ar.com.dgarcia.javaspec.api.JavaSpecApi;
 import ar.com.dgarcia.javaspec.api.contexts.TestContext;
 import ar.com.dgarcia.javaspec.api.exceptions.FailingRunnable;
 import ar.com.dgarcia.javaspec.api.exceptions.SpecException;
@@ -11,10 +10,10 @@ import java.util.function.Consumer;
 /**
  * Date: 30/03/19 - 16:36
  */
-public class InitialMode implements JavaSpecApi<TestContext> {
+public class InitialMode implements ExecutionMode<TestContext> {
 
-  public static <T extends TestContext> JavaSpecApi<T> create() {
-    return (JavaSpecApi<T>) new InitialMode();
+  public static <T extends TestContext> ExecutionMode<T> create() {
+    return (ExecutionMode<T>) new InitialMode();
   }
 
   @Override

--- a/src/main/java/ar/com/dgarcia/javaspec/impl/modes/RunningMode.java
+++ b/src/main/java/ar/com/dgarcia/javaspec/impl/modes/RunningMode.java
@@ -1,6 +1,5 @@
 package ar.com.dgarcia.javaspec.impl.modes;
 
-import ar.com.dgarcia.javaspec.api.JavaSpecApi;
 import ar.com.dgarcia.javaspec.api.contexts.TestContext;
 import ar.com.dgarcia.javaspec.api.exceptions.FailingRunnable;
 import ar.com.dgarcia.javaspec.api.exceptions.SpecException;
@@ -15,7 +14,7 @@ import java.util.function.Consumer;
  *
  * Created by kfgodel on 09/03/16.
  */
-public class RunningMode<T extends TestContext> implements JavaSpecApi<T> {
+public class RunningMode<T extends TestContext> implements ExecutionMode<T> {
 
   private T currentContext;
 


### PR DESCRIPTION
Although `JavaSpec` class shares an API with the different execution modes, they are not polymorphic when it comes to JavaSpec's `currentMode`. Furthermore, behavior could be added to execution modes that may not be desirable to add to `JavaSpec` class.

This is the first step necessary to separate JavaSpec-core from its implementations in different languages.