### PR TITLE
Simplify TestVariable interface

### DIFF
--- a/src/main/kotlin/ar/com/dgarcia/kotlinspec/api/variable/TestVariable.kt
+++ b/src/main/kotlin/ar/com/dgarcia/kotlinspec/api/variable/TestVariable.kt
@@ -30,4 +30,11 @@ open class TestVariable<out T>(val variableName: String, val context: () -> Test
         return context().get(variableName)
     }
 
+  /**
+   * Alias for [get] that allows to obtain the variable's value by calling it as a function
+   *
+   * @return The value of the variable
+   */
+  operator fun invoke(): T = get()
+
 }

--- a/src/main/kotlin/ar/com/dgarcia/kotlinspec/api/variable/TestVariable.kt
+++ b/src/main/kotlin/ar/com/dgarcia/kotlinspec/api/variable/TestVariable.kt
@@ -35,4 +35,11 @@ open class TestVariable<out T>(val variableName: String, val context: () -> Test
    */
   operator fun invoke(): T = get()
 
+  /**
+   * Alias for [set] that allows to set the variable's value by passing a block directly to the object
+   *
+   * @param definition A value supplier that can be used to lazily define the initial value of the variable
+   */
+  operator fun <U> invoke(definition: () -> U) = set(definition)
+
 }

--- a/src/main/kotlin/ar/com/dgarcia/kotlinspec/api/variable/TestVariable.kt
+++ b/src/main/kotlin/ar/com/dgarcia/kotlinspec/api/variable/TestVariable.kt
@@ -8,27 +8,25 @@ import ar.com.dgarcia.javaspec.api.contexts.TestContext
  */
 open class TestVariable<out T>(val variableName: String, val context: () -> TestContext) {
 
-    /**
-     * Defines the value in the current context, which may redefine previous value of broader context,
-     * or be redefined by a subcontext.<br></br> An exception is thrown if a variable is tried to be defined twice in same context
-     *
-     * @param definition A value supplier that can be used to lazily define the initial value of the variable
-     */
-    fun <U> set(definition: () -> U): TestVariable<U> {
-        context().let(variableName, definition)
-        return TestVariable(variableName, context)
-    }
+  /**
+   * Defines the value in the current context, which may redefine previous value of broader context,
+   * or be redefined by a subcontext.<br></br> An exception is thrown if a variable is tried to be defined twice in same context
+   *
+   * @param definition A value supplier that can be used to lazily define the initial value of the variable
+   */
+  fun <U> set(definition: () -> U): TestVariable<U> {
+    context().let(variableName, definition)
+    return TestVariable(variableName, context)
+  }
 
-    /**
-     * Gets the value defined in the current context or parent context.<br></br>
-     * The value of the variable is lazily defined the first time accessed. If there's no previous
-     * definition of the variable, then an exception will be thrown.
-     *
-     * @return The value of the variable
-     */
-    fun get(): T {
-        return context().get(variableName)
-    }
+  /**
+   * Gets the value defined in the current context or parent context.<br></br>
+   * The value of the variable is lazily defined the first time accessed. If there's no previous
+   * definition of the variable, then an exception will be thrown.
+   *
+   * @return The value of the variable
+   */
+  fun get(): T = context().get(variableName)
 
   /**
    * Alias for [get] that allows to obtain the variable's value by calling it as a function

--- a/src/test/kotlin/ar/com/dgarcia/javaspec/testSpecs/LetSpecTest.kt
+++ b/src/test/kotlin/ar/com/dgarcia/javaspec/testSpecs/LetSpecTest.kt
@@ -27,8 +27,12 @@ class LetSpecTest : KotlinSpec() {
         describe("and its value can be set in contexts") {
           foo.set { 1 }
 
-          it("can obtain that value") {
+          it("its value can be obtained with get()") {
             assertThat(foo.get()).isEqualTo(1)
+          }
+
+          it("its value can be obtained by calling the object as a function") {
+            assertThat(foo()).isEqualTo(1)
           }
 
           describe("when redefining its value in a sub-context") {

--- a/src/test/kotlin/ar/com/dgarcia/javaspec/testSpecs/LetSpecTest.kt
+++ b/src/test/kotlin/ar/com/dgarcia/javaspec/testSpecs/LetSpecTest.kt
@@ -25,14 +25,21 @@ class LetSpecTest : KotlinSpec() {
         }
 
         describe("and its value can be set in contexts") {
-          foo.set { 1 }
 
-          it("its value can be obtained with get()") {
-            assertThat(foo.get()).isEqualTo(1)
+          describe("using set()") {
+            foo.set { 1 }
+
+            it("its value can be obtained using get()") {
+              assertThat(foo.get()).isEqualTo(1)
+            }
           }
 
-          it("its value can be obtained by calling the object as a function") {
-            assertThat(foo()).isEqualTo(1)
+          describe("by passing a block with the value to the object") {
+            foo { 1 }
+
+            it("its value can be obtained by calling the object as a function") {
+              assertThat(foo()).isEqualTo(1)
+            }
           }
 
           describe("when redefining its value in a sub-context") {


### PR DESCRIPTION
Allows to use the TestVariable as a function, without needing to call set and get.